### PR TITLE
fix asterisk wasn't aligned

### DIFF
--- a/plugin/DoxygenToolkit.vim
+++ b/plugin/DoxygenToolkit.vim
@@ -456,6 +456,7 @@ function! <SID>DoxygenLicenseFunc()
     exec "normal %jA".l:date." - ".g:DoxygenToolkit_authorName
   endif
   exec "normal =%`d"
+  mark d
 
   call s:RestoreParameters()
 endfunction
@@ -495,6 +496,7 @@ function! <SID>DoxygenAuthorFunc()
 
   " Move the cursor to the rigth position
   exec "normal =%`d"
+  mark d
 
   call s:RestoreParameters()
   startinsert!
@@ -523,6 +525,7 @@ function! <SID>DoxygenUndocumentFunc(blockTag)
   endwhile
 
   exec "normal =%`d"
+  mark d
   call s:RestoreParameters()
 endfunction
 
@@ -544,6 +547,7 @@ function! <SID>DoxygenBlockFunc()
   exec "normal A".strpart( s:startCommentTag, 1 )." @} ".s:endCommentTag
   exec "set nopaste"
   exec "normal =%`d"
+  mark d
 
   call s:RestoreParameters()
   startinsert!
@@ -820,6 +824,7 @@ function! <SID>DoxygenCommentFunc()
     exec "normal A".strpart( s:startCommentBlock, 1 ).g:DoxygenToolkit_blockFooter.s:endCommentBlock
   endif
   exec "normal =%`d"
+  mark d
 
   call s:RestoreParameters()
   if( s:compactOneLineDoc =~ "yes" && s:endCommentTag != "" )

--- a/plugin/DoxygenToolkit.vim
+++ b/plugin/DoxygenToolkit.vim
@@ -456,7 +456,7 @@ function! <SID>DoxygenLicenseFunc()
     exec "normal %jA".l:date." - ".g:DoxygenToolkit_authorName
   endif
   exec "normal =%`d"
-  mark d
+  delmarks d
 
   call s:RestoreParameters()
 endfunction
@@ -496,7 +496,7 @@ function! <SID>DoxygenAuthorFunc()
 
   " Move the cursor to the rigth position
   exec "normal =%`d"
-  mark d
+  delmarks d
 
   call s:RestoreParameters()
   startinsert!
@@ -525,7 +525,7 @@ function! <SID>DoxygenUndocumentFunc(blockTag)
   endwhile
 
   exec "normal =%`d"
-  mark d
+  delmarks d
   call s:RestoreParameters()
 endfunction
 
@@ -547,7 +547,7 @@ function! <SID>DoxygenBlockFunc()
   exec "normal A".strpart( s:startCommentTag, 1 )." @} ".s:endCommentTag
   exec "set nopaste"
   exec "normal =%`d"
-  mark d
+  delmarks d
 
   call s:RestoreParameters()
   startinsert!
@@ -824,7 +824,7 @@ function! <SID>DoxygenCommentFunc()
     exec "normal A".strpart( s:startCommentBlock, 1 ).g:DoxygenToolkit_blockFooter.s:endCommentBlock
   endif
   exec "normal =%`d"
-  mark d
+  delmarks d
 
   call s:RestoreParameters()
   if( s:compactOneLineDoc =~ "yes" && s:endCommentTag != "" )

--- a/plugin/DoxygenToolkit.vim
+++ b/plugin/DoxygenToolkit.vim
@@ -455,7 +455,7 @@ function! <SID>DoxygenLicenseFunc()
   if( g:DoxygenToolkit_licenseTag == s:licenseTag )
     exec "normal %jA".l:date." - ".g:DoxygenToolkit_authorName
   endif
-  exec "normal `d"
+  exec "normal =%`d"
 
   call s:RestoreParameters()
 endfunction
@@ -494,7 +494,7 @@ function! <SID>DoxygenAuthorFunc()
   endif
 
   " Move the cursor to the rigth position
-  exec "normal `d"
+  exec "normal =%`d"
 
   call s:RestoreParameters()
   startinsert!
@@ -522,7 +522,7 @@ function! <SID>DoxygenUndocumentFunc(blockTag)
     endif
   endwhile
 
-  exec "normal `d"
+  exec "normal =%`d"
   call s:RestoreParameters()
 endfunction
 
@@ -534,13 +534,16 @@ endfunction
 function! <SID>DoxygenBlockFunc()
   call s:InitializeParameters()
 
+  exec "set paste"
   let l:insertionMode = s:StartDocumentationBlock()
   exec "normal ".l:insertionMode.s:interCommentTag.g:DoxygenToolkit_blockTag
   mark d
   exec "normal o".s:interCommentTag."@{ ".s:endCommentTag
+  exec "normal =%2j"
   exec "normal o".strpart( s:startCommentTag, 0, 1 )
   exec "normal A".strpart( s:startCommentTag, 1 )." @} ".s:endCommentTag
-  exec "normal `d"
+  exec "set nopaste"
+  exec "normal =%`d"
 
   call s:RestoreParameters()
   startinsert!
@@ -816,7 +819,7 @@ function! <SID>DoxygenCommentFunc()
     exec "normal o".strpart( s:startCommentBlock, 0, 1 )
     exec "normal A".strpart( s:startCommentBlock, 1 ).g:DoxygenToolkit_blockFooter.s:endCommentBlock
   endif
-  exec "normal `d"
+  exec "normal =%`d"
 
   call s:RestoreParameters()
   if( s:compactOneLineDoc =~ "yes" && s:endCommentTag != "" )


### PR DESCRIPTION
old version had a bug, the asterisk wasn't aligned, like this,

``` php
/**
      * @bref
      *
  */
```

now I fix, i will be aligned like this

``` php
/**
 * @bref
 *
 */
```
