### PR TITLE
Problem: Combination of `autoindent` and manual configuration of `g:D…

### DIFF
--- a/plugin/DoxygenToolkit.vim
+++ b/plugin/DoxygenToolkit.vim
@@ -552,6 +552,9 @@ endfunction
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 function! <SID>DoxygenCommentFunc()
 
+  " Prevent autoindent from placing too much indentation when placing spaces in manual configuration
+  set noautoindent
+
   " Initialize default templates.
   " Assure compatibility with Python for classes (cf. endDocPattern).
   let l:emptyLinePattern = '^[[:blank:]]*$'
@@ -838,6 +841,8 @@ function! <SID>DoxygenCommentFunc()
   "    call s:WarnMsg( "   - ".param )
   "  endfor
   "endif
+
+  set autoindent
 
 endfunction
 


### PR DESCRIPTION
Problem: Combination of `autoindent` and manual configuration of `g:DoxygenToolkit_start/inter/endCommentTag` with spaces in the
string would create documentation with too much indentation, such as:

> /**
>   * @brief ...
>       * @param ...
>           * @return ...
>               **/

                 
instead of the wanted:

> /**
>   * @brief
>   * @param
>   * @return
>   **/
> 

Added workaround: Disable autoindent at the start of the documenting function and enable it at the end.